### PR TITLE
add procedure for correct setup pathPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,6 @@ GitHubのリポジトリページにあるSettingsをクリックします。
 ![](static/GitHubSetting.png)
 
 Settingsページの下部にあるGitHubPages欄にあるURLより公開されたポートフォリオが確認できます。  
-
 ![](static/GitHubPages.png)
 
 ![](static/portfolio.png)

--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ GitHubでポートフォリオ用リポジトリを作成していきます。
 ![](static/GitHubCreate-Repo1.png)
 
 **Repository name**に適当なリポジトリ名を入力して、**Create repository**をクリックします。  
-**ここで決めたリポジトリ名は、後述のpathPrefixに記載します。なので忘れないようにしておきましょう**
-このREADMEでは **portfolio** をリポジトリ名にします。こだわりのない方は**portfolio**で作ることをお勧めます。
+**ここで決めたリポジトリ名は、後述のpathPrefixに記載します。なので忘れないようにしておきましょう**  
+このREADMEでは **portfolio** をリポジトリ名にします。こだわりのない方は**portfolio**で作ることをお勧めます。  
 ※ 基本デフォルト設定で今回行います。  
 ![](static/GitHubCreate-Repo2.png)
 
@@ -299,13 +299,13 @@ GithubPagesのドメインをそのまま使用する場合、gatsby-config.js�
 gatsby-config.jsに２つの設定を追加します。  
 
 module.exportsの中にpathPrefixを追加してください。  
-**pathPrefixの値は先程作成したリポジトリ名を使用します。**
+**pathPrefixの値は先程作成したリポジトリ名を使用します。**  
 ※ 13行目付近の「},」の下に追加  
 
 ```
 pathPrefix: "/{リポジトリ名}",
 ```
-このREADMEでは **portfolio** をリポジトリ名にしているので以下の用に設定します
+このREADMEでは **portfolio** をリポジトリ名にしているので以下のように設定します  
 ```
 pathPrefix: "/portfolio",
 ```

--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ GitHubでポートフォリオ用リポジトリを作成していきます。
 ![](static/GitHubCreate-Repo1.png)
 
 **Repository name**に適当なリポジトリ名を入力して、**Create repository**をクリックします。  
+**ここで決めたリポジトリ名は、後述のpathPrefixに記載します。なので忘れないようにしておきましょう**
+このREADMEでは **portfolio** をリポジトリ名にします。こだわりのない方は**portfolio**で作ることをお勧めます。
 ※ 基本デフォルト設定で今回行います。  
 ![](static/GitHubCreate-Repo2.png)
 
@@ -297,8 +299,13 @@ GithubPagesのドメインをそのまま使用する場合、gatsby-config.js�
 gatsby-config.jsに２つの設定を追加します。  
 
 module.exportsの中にpathPrefixを追加してください。  
+**pathPrefixの値は先程作成したリポジトリ名を使用します。**
 ※ 13行目付近の「},」の下に追加  
 
+```
+pathPrefix: "/{リポジトリ名}",
+```
+このREADMEでは **portfolio** をリポジトリ名にしているので以下の用に設定します
 ```
 pathPrefix: "/portfolio",
 ```
@@ -371,6 +378,7 @@ GitHubのリポジトリページにあるSettingsをクリックします。
 ![](static/GitHubSetting.png)
 
 Settingsページの下部にあるGitHubPages欄にあるURLより公開されたポートフォリオが確認できます。  
+
 ![](static/GitHubPages.png)
 
 ![](static/portfolio.png)


### PR DESCRIPTION
08/21 19:30から開かれた下記のMeetupに参加していた増井です.
https://www.wantedly.com/projects/483070
Profile: https://www.wantedly.com/users/18450787

github pagesの表示に失敗しており、昨日の時間中に解決できなかった点について解消ができました。
原因となった部分に関しての手順追記を行いましたので、もしお時間があればご確認いただければ幸いです。



# changes

* pathprefixの値には作成したリポジトリの名前を記載する旨を記載
* 既存のREADMEの画像に合わせて、README内ではリポジトリ名を`portfolio`とする旨を記載

# note

* github pagesの表示に失敗していた理由はpathprefixの値が間違っていたためでした、
* 私の作成したgithub pageは以下のURLですが、アクセスしてもグレーの画面しか表示されない
https://willco21.github.io/Gatsby-portfolio/
* ブラウザの開発コンソールで確認したところhttps://willco21.github.io/portfolio/ 以下のfileにアクセスできず、エラーが出ていることを確認
  * 当然そこにはfileは存在しない
* pathprefix について公式ドキュメントを確認したところ、以下のような説明があり、リポジトリ名を値にする必要があることを確認
https://www.gatsbyjs.com/docs/path-prefix/
  * デフォルトのgatsbyのページfileはdomein rootに展開されるが、github pagesの場合はリポジトリ名以下へのアクセスになるため、pathorefixにリポジトリ名を記載する必要がある

以下、ドキュメント抜粋
```
Many applications are hosted at something other than the root (/) of their domain.

For example, a Gatsby blog could live at example.com/blog/, or a site could be hosted on GitHub Pages at example.github.io/my-gatsby-site/.

Each of these sites need a prefix added to all paths on the site. So a link to /my-sweet-blog-post/ should be rewritten as /blog/my-sweet-blog-post.

In addition, links to various resources (JavaScript, CSS, images, and other static content) need the same prefix, so that the site continues to function correctly when served with the path prefix in place.
```

* 以下のように設定して `npm run deploy` を実行、リポジトリへのコミット後、ページが正しく表示されることを確認
```
pathprefix: `Gatsby-portfolio`
```